### PR TITLE
Do not hardcode serviceMonitor / Service name

### DIFF
--- a/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
+++ b/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
@@ -161,20 +161,23 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
- name: {{ include "citrix-ingress-controller.fullname" . }}-adc-servicemonitor
- labels:
-   servicemonitor: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc
+  name: {{ include "citrix-ingress-controller.fullname" . }}-adc-servicemonitor
+  labels:
+    servicemonitor: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc
+{{- if .Values.exporter.serviceMonitor.additionalLabels }}
+    {{ .Values.exporter.serviceMonitor.additionalLabels | nindent 4 }}
+{{ -end }}
 spec:
- endpoints:
- - interval: 30s
-   port: exporter-port
- selector:
-   matchLabels:
-     service-type: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc-monitor
- namespaceSelector:
-   matchNames:
-   - monitoring
-   - default
-   - {{ .Release.Namespace }}
+  endpoints:
+  - interval: 30s
+    port: exporter-port
+  selector:
+    matchLabels:
+      service-type: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc-monitor
+  namespaceSelector:
+    matchNames:
+    - monitoring
+    - default
+    - {{ .Release.Namespace }}
 
 {{- end }}

--- a/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
+++ b/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   selector:
 {{- if .Values.openshift }}
-     router: {{ include "citrix-ingress-controller.fullname" . }}
+    router: {{ include "citrix-ingress-controller.fullname" . }}
 {{- else }}
     matchLabels:
       app: {{ include "citrix-ingress-controller.fullname" . }}
@@ -139,21 +139,21 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-   name: {{ include "citrix-ingress-controller.fullname" . }}-exporter
-   labels:
-     app: {{ include "citrix-ingress-controller.fullname" . }}-exporter
-     service-type: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc-monitor
+  name: {{ include "citrix-ingress-controller.fullname" . }}-exporter
+  labels:
+    app: {{ include "citrix-ingress-controller.fullname" . }}-exporter
+    service-type: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc-monitor
 spec:
-   type: ClusterIP
-   ports:
-   - port: {{ .Values.exporter.ports.containerPort }}
-     targetPort: {{ .Values.exporter.ports.containerPort }}
-     name: exporter-port
-   selector:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.exporter.ports.containerPort }}
+    targetPort: {{ .Values.exporter.ports.containerPort }}
+    name: exporter-port
+  selector:
 {{- if .Values.openshift }}
-     router: {{ include "citrix-ingress-controller.fullname" . }}
+    router: {{ include "citrix-ingress-controller.fullname" . }}
 {{- else }}
-     app: {{ include "citrix-ingress-controller.fullname" . }}
+    app: {{ include "citrix-ingress-controller.fullname" . }}
 {{- end }}
 
 ---
@@ -166,7 +166,7 @@ metadata:
     servicemonitor: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc
 {{- if .Values.exporter.serviceMonitor.additionalLabels }}
     {{ .Values.exporter.serviceMonitor.additionalLabels | nindent 4 }}
-{{ -end }}
+{{- end }}
 spec:
   endpoints:
   - interval: 30s

--- a/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
+++ b/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
@@ -139,10 +139,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-   name: exporter
+   name: {{ include "citrix-ingress-controller.fullname" . }}-exporter
    labels:
-     app: exporter
-     service-type: citrix-adc-monitor
+     app: {{ include "citrix-ingress-controller.fullname" . }}-exporter
+     service-type: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc-monitor
 spec:
    type: ClusterIP
    ports:
@@ -161,16 +161,16 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
- name: citrix-adc-servicemonitor
+ name: {{ include "citrix-ingress-controller.fullname" . }}-adc-servicemonitor
  labels:
-   servicemonitor: citrix-adc
+   servicemonitor: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc
 spec:
  endpoints:
  - interval: 30s
    port: exporter-port
  selector:
    matchLabels:
-     service-type: citrix-adc-monitor
+     service-type: {{ include "citrix-ingress-controller.fullname" . }}-citrix-adc-monitor
  namespaceSelector:
    matchNames:
    - monitoring

--- a/citrix-ingress-controller/templates/rbac.yaml
+++ b/citrix-ingress-controller/templates/rbac.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "citrix-ingress-controller.serviceAccountName" . }}
 rules:
@@ -54,7 +54,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "citrix-ingress-controller.serviceAccountName" . }}
 roleRef:

--- a/citrix-ingress-controller/values.yaml
+++ b/citrix-ingress-controller/values.yaml
@@ -43,6 +43,9 @@ exporter:
   pullPolicy: IfNotPresent
   ports:
     containerPort: 8888
+  # serviceMonitor configuration
+  serviceMonitor:
+    additionalLabels: {}
 
 # For CRDs supported by Citrix Ingress Controller
 crds:


### PR DESCRIPTION
ServiceMonitor or Servicenames of the ADC Exporter shouldn't be hardcoded. Having more then one Citrix Ingress Controller in the same namespace doesn't work if we keep the same name for the adc exporter services.

Also add option additionalLabels to ServiceMonitor to be able to select it with prometheus.