### PR TITLE
Update serviceaccount.yaml

### DIFF
--- a/citrix-cloud-native/charts/citrix-node-controller/templates/serviceaccount.yaml
+++ b/citrix-cloud-native/charts/citrix-node-controller/templates/serviceaccount.yaml
@@ -28,6 +28,9 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "citrix-k8s-node-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: kube-chorus-router
+  namespace: {{ .Release.Namespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 
 ---


### PR DESCRIPTION
if you are using cnc the sa from kube-chorus-router has no access to the cluster because the Clusterrolebinding does not include kube-chorus-router SAs.