### PR TITLE
[citrix-ingress-controller] feat(extraVolumes): Addition

### DIFF
--- a/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
+++ b/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
@@ -114,6 +114,10 @@ spec:
         - name: "NS_LOGPROXY"
           value: "{{ .Values.logProxy }}"
 {{- end }}
+{{- if .Values.extraVolumes }}
+        VolumeMounts:
+        {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
+{{- end }}
 {{- if .Values.exporter.required }}
       - name: exporter
         image: "{{ .Values.exporter.image }}"
@@ -131,6 +135,12 @@ spec:
       - name: nslogin
         secret:
           secretName: {{ .Values.adcCredentialSecret }}
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{- if not .Values.exporter.required }}
+      volumes:
+{{- end }}
+      {{- toYaml .Values.extraVolumes | nindent 6 }}
 {{- end }}
 {{- if and .Values.nodeSelector.key .Values.nodeSelector.value }}
       nodeSelector:

--- a/citrix-ingress-controller/values.yaml
+++ b/citrix-ingress-controller/values.yaml
@@ -80,3 +80,6 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and `create` is true, a name is generated using the fullname template
   # name:
+
+extraVolumes: []
+extraVolumeMounts: []


### PR DESCRIPTION
* Adds extraVolume/Mounts to the Chart
* this allows us to deploy cic with additional volumemounts to implemente CSI Secret Provider Classes for holding the nslogin secret.

Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
