### PR TITLE
[BUG FIX] remove duplicate apiVersion entry at rbac.yaml

### DIFF
--- a/citrix-cpx-with-ingress-controller/templates/rbac.yaml
+++ b/citrix-cpx-with-ingress-controller/templates/rbac.yaml
@@ -68,7 +68,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "citrix-cpx-ingress-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-apiVersion: rbac.authorization.k8s.io/v1
 
 ---
 

--- a/citrix-ingress-controller/templates/rbac.yaml
+++ b/citrix-ingress-controller/templates/rbac.yaml
@@ -68,7 +68,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "citrix-ingress-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-apiVersion: rbac.authorization.k8s.io/v1
 
 ---
 


### PR DESCRIPTION
Fellow Citrix Team

I've been facing the following error when installing the citrix-ingress-controller via the helm-controller from [flux2](https://github.com/fluxcd/flux2):

```
helm-controller  Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 17: mapping key "apiVersion" already defined at line 3
```

So I started debugging your Helm chart, because other ones from other projects were applied successfully.
I figured out, that you have a duplicated entry in the rbac.yaml files of the both ingress-controller helm charts:
- https://github.com/citrix/citrix-helm-charts/blob/8998c1e30d171c286f8d92611bbbe65d280012a1/citrix-ingress-controller/templates/rbac.yaml#L71
- https://github.com/citrix/citrix-helm-charts/blob/8998c1e30d171c286f8d92611bbbe65d280012a1/citrix-cpx-with-ingress-controller/templates/rbac.yaml#L71

I've deleted these lines and tested it for myself, and now it's applying perfectly.
Please merge my PR into your upstream helm charts to fix this issue.

Thank you very much and kind regards
Jan Lauber
Signed-off-by: Jan Lauber <jan.lauber@protonmail.ch>