### PR TITLE
ingress-controller: add namespace into deployment metadata

### DIFF
--- a/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
+++ b/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 {{- end }}
 metadata:
   name: {{ include "citrix-ingress-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
 {{- if .Values.openshift }}


### PR DESCRIPTION
similar issue with #113 

ingress-controller/deployment metadata didn't include user configured namespace data.
this chart's serviceaccount has namespace metadata, but deployment not.

regards.