### PR TITLE
Add missing description for redirect_url

### DIFF
--- a/citrix-ingress-controller/templates/cic_crds.yaml
+++ b/citrix-ingress-controller/templates/cic_crds.yaml
@@ -1776,7 +1776,7 @@ spec:
                 description: 'Location of external signature file'
                 type: string
               redirect_url:
-                description: ''
+                description: 'URL to redirect to when a URL is blocked'
                 type: string
               html_error_object:
                 description: 'Location of customized error page to respond when html or common violation are hit'


### PR DESCRIPTION
Some background:
When installing the chart using ArgoCD the description is automatically added as `description: ''` which makes the installation seem out of sync. Adding a description fixes this use-case.