### PR TITLE
typo --ingress-classes

### DIFF
--- a/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
+++ b/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
@@ -55,7 +55,7 @@ spec:
             {{ .Release.Namespace }}/{{ .Values.defaultSSLCertSecret }}
 {{- end }}
 {{- if .Values.ingressClass }}
-          - --ingress-class
+          - --ingress-classes
 {{- range .Values.ingressClass}}
             {{.}}
 {{- end }}


### PR DESCRIPTION
As the ingress controller document describes, i guess "--ingress-classes" is the right argument. 

https://docs.citrix.com/en-us/citrix-k8s-ingress-controller/configure/ingress-classes.html