### PR TITLE
Add extra labels to servicemonitor

### DIFF
--- a/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
+++ b/citrix-ingress-controller/templates/citrix-k8s-ingress.yaml
@@ -248,6 +248,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     servicemonitor: citrix-adc
+    {{- with .Values.exporter.serviceMonitorExtraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
   - interval: 30s

--- a/citrix-ingress-controller/values.yaml
+++ b/citrix-ingress-controller/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 openshift: false
 adcCredentialSecret: # K8s Secret Name
 # Enable secretStore to implement CSI Secret Provider classes for holding the nslogin credentials
-secretStore: 
+secretStore:
   enabled: false
   username: {}
     #valueFrom:
@@ -115,6 +115,7 @@ exporter:
   #  readOnly: true
   #- name: agent-init-scripts
   #  mountPath: /docker-entrypoint.d/
+  serviceMonitorExtraLabels: {}
 
 # For CRDs supported by Citrix Ingress Controller
 crds:


### PR DESCRIPTION
[citrix-ingress-controller] Simple patch to add extra labels to service monitor when exporter enabled.
Do nothing by default
related to this [issue](https://github.com/citrix/citrix-helm-charts/issues/156)